### PR TITLE
Fix failing test and update the title element on the home page.

### DIFF
--- a/src/test/java/hello/HomePageTest.java
+++ b/src/test/java/hello/HomePageTest.java
@@ -39,7 +39,7 @@ public class HomePageTest {
                 .andExpect(xpath(BootstrapLiterals.bootstrapCSSXpath).exists());
         for (String s: BootstrapLiterals.bootstrapJSurls) {
             String jsXPath = String.format("//script[@src='%s']",s);
-            mvc.perform(MockMvcRequestBuilders.get("/greeting").accept(MediaType.TEXT_HTML))
+            mvc.perform(MockMvcRequestBuilders.get("/").accept(MediaType.TEXT_HTML))
               .andExpect(status().isOk())
               .andExpect(xpath(jsXPath).exists());
         }


### PR DESCRIPTION
In this PR we fix two failing tests:
- The title element of the home page was incorrect.
- There was a typo in the test case for bootstrap is/css files.